### PR TITLE
Changing Topic names to be consistent with text and diagrams

### DIFF
--- a/2_streaming_data/c++11/temperature_publisher.cxx
+++ b/2_streaming_data/c++11/temperature_publisher.cxx
@@ -33,14 +33,14 @@ void run_example(
     dds::domain::DomainParticipant participant(domain_id);
 
     // A Topic has a name and a datatype. Create a Topic named
-    // "Chocolate Temperature" with type Temperature
-    dds::topic::Topic<Temperature> topic(participant, "Chocolate Temperature");
+    // "ChocolateTemperature" with type Temperature
+    dds::topic::Topic<Temperature> topic(participant, "ChocolateTemperature");
 
     // A Publisher allows an application to create one or more DataWriters
     // Publisher QoS is configured in USER_QOS_PROFILES.xml
     dds::pub::Publisher publisher(participant);
 
-    // This DataWriter writes data on Topic "Chocolate Temperature"
+    // This DataWriter writes data on Topic "ChocolateTemperature"
     // DataWriter QoS is configured in USER_QOS_PROFILES.xml
     dds::pub::DataWriter<Temperature> writer(publisher, topic);
 

--- a/2_streaming_data/c++11/temperature_subscriber.cxx
+++ b/2_streaming_data/c++11/temperature_subscriber.cxx
@@ -47,15 +47,15 @@ void run_example(unsigned int domain_id, unsigned int sample_count)
     dds::domain::DomainParticipant participant(domain_id);
 
     // A Topic has a name and a datatype. Create a Topic named
-    // "Chocolate Temperature" with type Temperature
-    dds::topic::Topic<Temperature> topic(participant, "Chocolate Temperature");
+    // "ChocolateTemperature" with type Temperature
+    dds::topic::Topic<Temperature> topic(participant, "ChocolateTemperature");
 
     // A Subscriber allows an application to create one or more DataReaders
     // Subscriber QoS is configured in USER_QOS_PROFILES.xml
     dds::sub::Subscriber subscriber(participant);
 
     // This DataReader reads data of type Temperature on Topic
-    // "Chocolate Temperature". DataReader QoS is configured in
+    // "ChocolateTemperature". DataReader QoS is configured in
     // USER_QOS_PROFILES.xml
     dds::sub::DataReader<Temperature> reader(subscriber, topic);
 

--- a/2_streaming_data/c++98/temperature_publisher.cxx
+++ b/2_streaming_data/c++98/temperature_publisher.cxx
@@ -65,9 +65,9 @@ int run_example(
     }
 
     // A Topic has a name and a datatype. Create a Topic called
-    // "Chocolate Temperature" with your registered data type
+    // "ChocolateTemperature" with your registered data type
     DDSTopic *topic = participant->create_topic(
-            "Chocolate Temperature",
+            "ChocolateTemperature",
             type_name,
             DDS_TOPIC_QOS_DEFAULT,
             NULL /* listener */,
@@ -76,7 +76,7 @@ int run_example(
         return shutdown(participant, "create_topic error", EXIT_FAILURE);
     }
 
-    // This DataWriter writes data on Topic "Chocolate Temperature"
+    // This DataWriter writes data on Topic "ChocolateTemperature"
     // DataWriter QoS is configured in USER_QOS_PROFILES.xml
     DDSDataWriter *writer = publisher->create_datawriter(
             topic,

--- a/2_streaming_data/c++98/temperature_subscriber.cxx
+++ b/2_streaming_data/c++98/temperature_subscriber.cxx
@@ -90,9 +90,9 @@ int run_example(unsigned int domain_id, unsigned int sample_count)
     }
 
     // A Topic has a name and a datatype. Create a Topic called
-    // "Chocolate Temperature" with your registered data type
+    // "ChocolateTemperature" with your registered data type
     DDSTopic *topic = participant->create_topic(
-            "Chocolate Temperature",
+            "ChocolateTemperature",
             type_name,
             DDS_TOPIC_QOS_DEFAULT,
             NULL /* listener */,
@@ -102,7 +102,7 @@ int run_example(unsigned int domain_id, unsigned int sample_count)
     }
 
     // This DataReader reads data of type Temperature on Topic
-    // "Chocolate Temperature". DataReader QoS is configured in
+    // "ChocolateTemperature". DataReader QoS is configured in
     // USER_QOS_PROFILES.xml
     DDSDataReader *reader = subscriber->create_datareader(
             topic,


### PR DESCRIPTION
Change to Topic names to match what we have in the written text and diagrams.