### PR TITLE
Remove incorrect variable assignment

### DIFF
--- a/resources/cmake/ConnextDdsCodegen.cmake
+++ b/resources/cmake/ConnextDdsCodegen.cmake
@@ -441,7 +441,6 @@ function(_connextdds_codegen_get_generated_file_list)
             # Set in the parent scope
             set(${_CODEGEN_VAR}_GENERATED_SOURCES ${sources} PARENT_SCOPE)
             set(${_CODEGEN_VAR}_SOURCES ${sources} PARENT_SCOPE)
-            set(${_CODEGEN_VAR}_HEADERS ${headers} PARENT_SCOPE)
             set(${_CODEGEN_VAR}_PUBLISHER_SOURCE PARENT_SCOPE)
             set(${_CODEGEN_VAR}_SUBSCRIBER_SOURCE PARENT_SCOPE)
         endif()


### PR DESCRIPTION
`${_CODEGEN_VAR}_HEADERS` was being assigned to the value of a undeclared variable in the else statement. I removed the assignment because the `${_CODEGEN_VAR}_HEADERS` is being initialized outside the conditional block (right [here](https://github.com/rticommunity/rticonnextdds-getting-started/blob/d03601db5aece9dfc90d98916777e660bf711283/resources/cmake/ConnextDdsCodegen.cmake#L426)).