### PR TITLE
IRONSIDE-1166 -- from release/7.3.0, correct csproj version strings in master.

### DIFF
--- a/4_keys_instances/csharp/ChocolateFactoryTypes/ChocolateFactoryTypes.csproj
+++ b/4_keys_instances/csharp/ChocolateFactoryTypes/ChocolateFactoryTypes.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
   </ItemGroup>
 
 </Project>

--- a/4_keys_instances/csharp/MonitoringCtrlApplication/MonitoringCtrlApplication.csproj
+++ b/4_keys_instances/csharp/MonitoringCtrlApplication/MonitoringCtrlApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/4_keys_instances/csharp/TemperingApplication/TemperingApplication.csproj
+++ b/4_keys_instances/csharp/TemperingApplication/TemperingApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/5_basic_qos/csharp/ChocolateFactoryTypes/ChocolateFactoryTypes.csproj
+++ b/5_basic_qos/csharp/ChocolateFactoryTypes/ChocolateFactoryTypes.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
   </ItemGroup>
 
 </Project>

--- a/5_basic_qos/csharp/MonitoringCtrlApplication/MonitoringCtrlApplication.csproj
+++ b/5_basic_qos/csharp/MonitoringCtrlApplication/MonitoringCtrlApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/5_basic_qos/csharp/TemperingApplication/TemperingApplication.csproj
+++ b/5_basic_qos/csharp/TemperingApplication/TemperingApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/6_content_filters/csharp/ChocolateFactoryTypes/ChocolateFactoryTypes.csproj
+++ b/6_content_filters/csharp/ChocolateFactoryTypes/ChocolateFactoryTypes.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
   </ItemGroup>
 
 </Project>

--- a/6_content_filters/csharp/IngredientApplication/IngredientApplication.csproj
+++ b/6_content_filters/csharp/IngredientApplication/IngredientApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/6_content_filters/csharp/MonitoringCtrlApplication/MonitoringCtrlApplication.csproj
+++ b/6_content_filters/csharp/MonitoringCtrlApplication/MonitoringCtrlApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 

--- a/6_content_filters/csharp/TemperingApplication/TemperingApplication.csproj
+++ b/6_content_filters/csharp/TemperingApplication/TemperingApplication.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Rti.ConnextDds" Version="7.2.0" />
+    <PackageReference Include="Rti.ConnextDds" Version="7.3.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20303.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This step should have been completed when we relesae 7.3.0. This will correct that omission. This takes the version string from 7.3.0, and replaces the current 7.2.0 string.